### PR TITLE
Fixed Installation Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage:
 
 1. Install `django-paystack`
 ```
-pip install -e https://github.com/gbozee/django-paystack.git@master#egg=paystack
+pip install -e git+https://github.com/gbozee/django-paystack.git@master#egg=paystack
 ```
 
 2. Add `paystack` to your `settings` module


### PR DESCRIPTION
Running the `pip install -e https://github.com/gbozee/django-paystack.git@master#egg=paystack` raises a **_https://github.com/gbozee/django-paystack.git@master#egg=paystack should either be a path to a local project or a VCS url beginning with svn+, git+, hg+, or bzr+_** error.

After reading the pypi docs,  I figured there should be a _**git+**_ before the url.

So, I added it to the installation command.

The new url is _**pip install -e git+https://github.com/gbozee/django-paystack.git@master#egg=paystack**_